### PR TITLE
[PLAT-11587] Update emsdk with changes from upstream emscripten

### DIFF
--- a/emsdk_manifest.json
+++ b/emsdk_manifest.json
@@ -297,8 +297,17 @@
     "activated_cfg": "NODE_JS='%installation_dir%/bin/node%.exe%'",
     "activated_env": "EMSDK_NODE=%installation_dir%/bin/node%.exe%"
   },
-
-
+  {
+    "id": "node",
+    "version": "20.18.0",
+    "arch": "arm64",
+    "bitness": 64,
+    "macos_url": "node-v20.18.0-darwin-arm64.tar.gz",
+    "activated_path": "%installation_dir%/bin",
+    "activated_path_skip": "node",
+    "activated_cfg": "NODE_JS='%installation_dir%/bin/node%.exe%'",
+    "activated_env": "EMSDK_NODE=%installation_dir%/bin/node%.exe%"
+  },
   {
     "id": "python",
     "version": "2.7.13.1",
@@ -641,7 +650,7 @@
   {
     "version": "releases-%releases-tag%",
     "bitness": 64,
-    "uses": ["node-15.14.0-64bit", "python-3.9.2-64bit", "releases-%releases-tag%-64bit"],
+    "uses": ["node-20.18.0-64bit", "python-3.9.2-64bit", "releases-%releases-tag%-64bit"],
     "os": "macos",
     "arch": "aarch64",
     "custom_install_script": "emscripten_npm_install"


### PR DESCRIPTION
To support a native Apple Silicon version of emscripten, we needed to update the version of node used. We decided to pull all the changes from upstream emscripten in, which includes the node update. These changes are the result of rebasing [the upstream branch](https://github.com/emscripten-core/emsdk) onto [3.1.38-unity](https://github.com/Unity-Technologies/emsdk/tree/3.1.38-unity). 