### PR TITLE
[PLAT-11587] Update Mac Arm64 version of node

### DIFF
--- a/emsdk.py
+++ b/emsdk.py
@@ -2263,6 +2263,7 @@ def load_sdk_manifest():
           continue
 
       if is_sdk:
+        print("Processing SDK:" + str(t2))
         if dependencies_exist(t2):
           if not find_sdk(t2.name):
             add_sdk(t2)

--- a/emsdk.py
+++ b/emsdk.py
@@ -151,7 +151,6 @@ elif machine.startswith('arm'):
 else:
   exit_with_error('unknown machine architecture: ' + machine)
 
-
 # Don't saturate all cores to not steal the whole system, but be aggressive.
 CPU_CORES = int(os.getenv('EMSDK_NUM_CORES', max(multiprocessing.cpu_count() - 1, 1)))
 

--- a/emsdk.py
+++ b/emsdk.py
@@ -2263,7 +2263,6 @@ def load_sdk_manifest():
           continue
 
       if is_sdk:
-        print("Processing SDK:" + str(t2))
         if dependencies_exist(t2):
           if not find_sdk(t2.name):
             add_sdk(t2)

--- a/emsdk_manifest.json
+++ b/emsdk_manifest.json
@@ -617,16 +617,8 @@
   {
     "version": "main",
     "bitness": 64,
-    "uses": ["python-3.9.2-64bit", "llvm-git-main-64bit", "node-15.14.0-64bit", "emscripten-main-64bit", "binaryen-main-64bit"],
-    "os": "macos",
-    "arch": "x86_64"
-  },
-  {
-    "version": "main",
-    "bitness": 64,
     "uses": ["python-3.9.2-64bit", "llvm-git-main-64bit", "node-20.18.0-64bit", "emscripten-main-64bit", "binaryen-main-64bit"],
-    "os": "macos",
-    "arch": "arm64"
+    "os": "macos"
   },
   {
     "version": "main",

--- a/emsdk_manifest.json
+++ b/emsdk_manifest.json
@@ -297,8 +297,17 @@
     "activated_cfg": "NODE_JS='%installation_dir%/bin/node%.exe%'",
     "activated_env": "EMSDK_NODE=%installation_dir%/bin/node%.exe%"
   },
-
-
+  {
+    "id": "node",
+    "version": "20.18.0",
+    "arch": "arm64",
+    "bitness": 64,
+    "macos_url": "node-v20.18.0-darwin-arm64.tar.gz",
+    "activated_path": "%installation_dir%/bin",
+    "activated_path_skip": "node",
+    "activated_cfg": "NODE_JS='%installation_dir%/bin/node%.exe%'",
+    "activated_env": "EMSDK_NODE=%installation_dir%/bin/node%.exe%"
+  },
   {
     "id": "python",
     "version": "2.7.13.1",
@@ -641,7 +650,7 @@
   {
     "version": "releases-%releases-tag%",
     "bitness": 64,
-    "uses": ["node-15.14.0-64bit", "python-3.9.2-64bit", "releases-%releases-tag%-64bit"],
+    "uses": ["node-20.18.0-64bit", "python-3.9.2-64bit", "releases-%releases-tag%-64bit"],
     "os": "macos",
     "arch": "aarch64",
     "custom_install_script": "emscripten_npm_install"

--- a/emsdk_manifest.json
+++ b/emsdk_manifest.json
@@ -47,7 +47,7 @@
     "id": "releases",
     "version": "%releases-tag%",
     "bitness": 64,
-    "arch": "aarch64",
+    "arch": "arm64",
     "macos_url": "https://storage.googleapis.com/webassembly/emscripten-releases-builds/mac/%releases-tag%/wasm-binaries-arm64.tbz2",
     "linux_url": "https://storage.googleapis.com/webassembly/emscripten-releases-builds/linux/%releases-tag%/wasm-binaries-arm64.tbz2",
     "zipfile_prefix": "%releases-tag%-",
@@ -96,7 +96,7 @@
   {
     "id": "node",
     "version": "8.9.1",
-    "arch": "aarch64",
+    "arch": "arm64",
     "bitness": 64,
     "linux_url": "node-v8.9.1-linux-arm64.tar.xz",
     "activated_path": "%installation_dir%/bin",
@@ -142,7 +142,7 @@
   {
     "id": "node",
     "version": "12.18.1",
-    "arch": "aarch64",
+    "arch": "arm64",
     "bitness": 64,
     "linux_url": "node-v12.18.1-linux-arm64.tar.xz",
     "activated_path": "%installation_dir%/bin",
@@ -190,7 +190,7 @@
   {
     "id": "node",
     "version": "14.18.2",
-    "arch": "aarch64",
+    "arch": "arm64",
     "bitness": 64,
     "macos_url": "node-v14.18.2-darwin-x64.tar.gz",
     "linux_url": "node-v14.18.2-linux-arm64.tar.xz",
@@ -239,7 +239,7 @@
   {
     "id": "node",
     "version": "14.15.5",
-    "arch": "aarch64",
+    "arch": "arm64",
     "bitness": 64,
     "macos_url": "node-v14.15.5-darwin-x64.tar.gz",
     "linux_url": "node-v14.15.5-linux-arm64.tar.xz",
@@ -288,7 +288,7 @@
   {
     "id": "node",
     "version": "15.14.0",
-    "arch": "aarch64",
+    "arch": "arm64",
     "bitness": 64,
     "macos_url": "node-v15.14.0-darwin-x64.tar.gz",
     "linux_url": "node-v15.14.0-linux-arm64.tar.xz",
@@ -409,7 +409,7 @@
     "id": "python",
     "version": "3.9.2",
     "bitness": 64,
-    "arch": "aarch64",
+    "arch": "arm64",
     "macos_url": "python-3.9.2-1-macos-arm64.tar.gz",
     "activated_cfg": "PYTHON='%installation_dir%/bin/python3'",
     "activated_env": "EMSDK_PYTHON=%installation_dir%/bin/python3;SSL_CERT_FILE=%installation_dir%/lib/python3.9/site-packages/certifi/cacert.pem"
@@ -652,7 +652,7 @@
     "bitness": 64,
     "uses": ["node-20.18.0-64bit", "python-3.9.2-64bit", "releases-%releases-tag%-64bit"],
     "os": "macos",
-    "arch": "aarch64",
+    "arch": "arm64",
     "custom_install_script": "emscripten_npm_install"
   },
   {

--- a/emsdk_manifest.json
+++ b/emsdk_manifest.json
@@ -623,6 +623,13 @@
   {
     "version": "main",
     "bitness": 64,
+    "uses": ["python-3.9.2-64bit", "llvm-git-main-64bit", "node-20.18.0-64bit", "emscripten-main-64bit", "binaryen-main-64bit"],
+    "os": "macos",
+    "arch": "aarch64"
+  },
+  {
+    "version": "main",
+    "bitness": 64,
     "uses": ["llvm-git-main-64bit", "node-15.14.0-64bit", "emscripten-main-64bit", "binaryen-main-64bit"],
     "os": "linux"
   },

--- a/emsdk_manifest.json
+++ b/emsdk_manifest.json
@@ -618,14 +618,15 @@
     "version": "main",
     "bitness": 64,
     "uses": ["python-3.9.2-64bit", "llvm-git-main-64bit", "node-15.14.0-64bit", "emscripten-main-64bit", "binaryen-main-64bit"],
-    "os": "macos"
+    "os": "macos",
+    "arch": "x86_64"
   },
   {
     "version": "main",
     "bitness": 64,
     "uses": ["python-3.9.2-64bit", "llvm-git-main-64bit", "node-20.18.0-64bit", "emscripten-main-64bit", "binaryen-main-64bit"],
     "os": "macos",
-    "arch": "aarch64"
+    "arch": "arm64"
   },
   {
     "version": "main",

--- a/emsdk_manifest.json
+++ b/emsdk_manifest.json
@@ -618,7 +618,15 @@
     "version": "main",
     "bitness": 64,
     "uses": ["python-3.9.2-64bit", "llvm-git-main-64bit", "node-20.18.0-64bit", "emscripten-main-64bit", "binaryen-main-64bit"],
-    "os": "macos"
+    "os": "macos",
+    "arch": "arm64"
+  },
+  {
+    "version": "main",
+    "bitness": 64,
+    "uses": ["python-3.9.2-64bit", "llvm-git-main-64bit", "node-15.14.0-64bit", "emscripten-main-64bit", "binaryen-main-64bit"],
+    "os": "macos",
+    "arch": "x86_64"
   },
   {
     "version": "main",


### PR DESCRIPTION
## Description
This PR is for updating the version of node we're using for building emscripten for Mac Arm64. This change was needed because the [Build Emsdk Mac (M1 Arm64) job](https://unity-ci.cds.internal.unity3d.com/project/949/branch/rsimm-test/jobDefinition/.yamato%2Fbuild_mac_arm64.yml%23mac-arm64) was failing with the error that the version of node we were using wasn't compatible with our CPU. This is because Mac M1 is only supported by node versions 16 or higher. This PR updates the node version being used by the job to be 20.18.0, which is the most up to date node version being used by the [upstream emsdk repository](https://github.com/emscripten-core/emsdk) at the time of writing this PR. Also included in this PR is [this change](https://github.com/emscripten-core/emsdk/pull/1246) which was cherry-picked from the upstream emsdk repository. This was necessary to add because previously we had references to "arm64" and "aarch64" which represented the same architecture, but conflicted with each other when they shouldn't because we were using two separate names for the same thing.

## Testing
1. Passing yamato job: https://unity-ci.cds.internal.unity3d.com/job/47292045
2. Passing Build All Emsdk suite to ensure no regressions to other OSes: https://unity-ci.cds.internal.unity3d.com/job/47382044/results
3. Manually verified using the file command that the node, python, emscripten, binaryen, and llvm binaries generated as part of the artifact were for Mac Arm64